### PR TITLE
rm: fix 3 signedness warnings

### DIFF
--- a/src/rm/rm.c
+++ b/src/rm/rm.c
@@ -60,7 +60,7 @@ int	check(char *, char *, struct stat *);
 void	checkdot(char **);
 void	rm_file(char **);
 int	rm_overwrite(char *, struct stat *);
-int	pass(int, off_t, char *, size_t);
+int	pass(int, off_t, char *, ssize_t);
 void	rm_tree(char **);
 void	usage(void);
 
@@ -339,9 +339,9 @@ err:
 }
 
 int
-pass(int fd, off_t len, char *buf, size_t bsize)
+pass(int fd, off_t len, char *buf, ssize_t bsize)
 {
-	size_t wlen;
+	ssize_t wlen;
 
 	for (; len > 0; len -= wlen) {
 		wlen = len < bsize ? len : bsize;


### PR DESCRIPTION
Fixes warnings mentioned at
https://github.com/theimpossibleastronaut/rmw/discussions/372#discussioncomment-4770185

I think write() returns a ssize_t on both Linux and BSD?

https://www.freebsd.org/cgi/man.cgi?write(2)

```
../src/bsd-coreutils/rm.c: In function ‘pass’:
../src/bsd-coreutils/rm.c:347:28: warning: comparison of integer
expressions of different signedness: ‘off_t’ {aka ‘long int’} and
‘size_t’ {aka ‘long unsigned int’} [-Wsign-compare]
  347 |                 wlen = len < bsize ? len : bsize;
      |                            ^
../src/bsd-coreutils/rm.c:347:38: warning: operand of ‘?:’ changes
signedness from ‘off_t’ {aka ‘long int’} to ‘size_t’ {aka ‘long unsigned
int’} due to unsignedness of other operand [-Wsign-compare]
  347 |                 wlen = len < bsize ? len : bsize;
      |                                      ^~~
../src/bsd-coreutils/rm.c:350:42: warning: comparison of integer
expressions of different signedness: ‘ssize_t’ {aka ‘long int’} and
‘size_t’ {aka ‘long unsigned int’} [-Wsign-compare]
  350 |                 if (write(fd, buf, wlen) != wlen)
```